### PR TITLE
Remove example unzcrash.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(MSVC OR MSVC90 OR MSVC10)
   set(MSVC ON)
 endif (MSVC OR MSVC90 OR MSVC10)
 
-set(bzip2_STAT_SRCS blocksort.c  bzlib.c compress.c  crctable.c  decompress.c  huffman.c randtable.c  unzcrash.c)
+set(bzip2_STAT_SRCS blocksort.c bzlib.c compress.c  crctable.c  decompress.c  huffman.c randtable.c)
 
 add_library(bz2 ${bzip2_STAT_SRCS})
 add_executable(bzip2 bzip2.c)


### PR DESCRIPTION
unzcrash.c is just a test program which contains `main()`.